### PR TITLE
Correction d'erreurs de syntaxe et d'exécution

### DIFF
--- a/src/main/java/com/openclassrooms/ideinstall/BasicExample.java
+++ b/src/main/java/com/openclassrooms/ideinstall/BasicExample.java
@@ -3,9 +3,9 @@ package com.openclassrooms.ideinstall;
 public class BasicExample {
 
 	public static void main(String[] args) {
-		final int index;
-		for(i=0; i>=0; i++) {
-			System.out.println("Hello bugs !"):
+		int i;
+		for (i = 0; i < 3; i++) {
+			System.out.println("Hello bugs !");
 		}
 	}
 }


### PR DESCRIPTION
variable int renommée en i
variable non finale
fin de boucle dès que i >= 3
erreur syntaxe (: au lieu de ;)