### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Exemple avec bugs du cours OC pour installer l'IDE Java Eclipse
 
 Exemple utilisé dans le cours introductif OpenClassrooms "Installez votre environnement de développement Java avec Eclipse".
+
+## NOTE pour le commit/push sur GitHub (ajoutée en février 2024) : 
+Depuis le 13 août 2021, GitHub n'autorise plus l'accès par authentification simple à ses API (c'est quoi une [API](https://fr.wikipedia.org/wiki/Interface_de_programmation)?), comme expliqué [ici](https://github.blog/changelog/2021-08-12-git-password-authentication-is-shutting-down/) par GitHub. (...Eclipse utilise les API pour mettre à jour GithHub ! Oups.)
+
+:tada: La solution pour contourner le problème est décrite dans l'issue #1102 (https://github.com/geoffreyarthaud/oc-install-ide-cours/issues/1102)


### PR DESCRIPTION
NOTE pour le commit/push sur GitHub (ajoutée en février 2024) :

Depuis le 13 août 2021, GitHub n'autorise plus l'accès par authentification simple à ses API (c'est quoi une API?), comme expliqué ici par GitHub. (...Eclipse utilise les API pour mettre à jour GithHub ! Oups.)

🎉 La solution pour contourner le problème est décrite dans l'issue #1102 (#1102)